### PR TITLE
[DEV-4165]: ERC20 transfer history

### DIFF
--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -458,4 +458,15 @@ export default createSchema((p) => ({
 		value: p.string(),
 		amount: p.bigint(),
 	}),
+
+	StablecoinTransferHistory: p.createTable({
+		id: p.string(),
+		from: p.string(),
+		to: p.string(),
+		amount: p.bigint(),
+		timestamp: p.bigint(),
+		txHash: p.string(),
+		blockheight: p.bigint(),
+		transactionTo: p.string().optional(),
+	}),
 }));

--- a/src/stablecoin.ts
+++ b/src/stablecoin.ts
@@ -177,7 +177,21 @@ ponder.on('Stablecoin:Transfer', async ({ event, context }) => {
 		BridgeEUROP,
 		BridgeEURI,
 		BridgeEURE,
+		StablecoinTransferHistory,
 	} = context.db;
+
+	await StablecoinTransferHistory.create({
+		id: `${event.transaction.from}-${event.transaction.to}-${getRandomHex()}`,
+		data: {
+			from: event.args.from,
+			to: event.args.to,
+			amount: event.args.value,
+			timestamp: event.block.timestamp,
+			blockheight: event.block.number,
+			txHash: event.transaction.hash,
+			transactionTo: event.transaction.to ?? undefined,
+		},
+	});
 
 	await Ecosystem.upsert({
 		id: 'Stablecoin:TransferCounter',


### PR DESCRIPTION
This makes available the following data per ERC20 transfer:

**from** - Sender's address (who sent the tokens)
**to** - Recipient's address (who received the tokens)
**amount** - Amount of tokens transferred (in wei/smallest unit)
**timestamp** - Unix timestamp when the transfer occurred
**txHash** - Transaction hash of the blockchain transaction
**blockheight** - Block number where the transfer was included
**transactionTo** - The contract address that was called (optional) (so you can know if it is a bridge transaction, savings related, etc...)
