### PR TITLE
feat: Add SavingsStats table for aggregated statistics

### DIFF
--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -170,6 +170,12 @@ export default createSchema((p) => ({
 		interestReceived: p.bigint(),
 	}),
 
+	SavingsStats: p.createTable({
+		id: p.string(), // Will be 'global' for single row
+		totalUsers: p.int(),
+		lastUpdated: p.bigint(),
+	}),
+
 	SavingsTotalHistory: p.createTable({
 		id: p.string(),
 		time: p.bigint(),

--- a/src/Savings.ts
+++ b/src/Savings.ts
@@ -48,6 +48,7 @@ ponder.on('Savings:Saved', async ({ event, context }) => {
 		Ecosystem,
 		SavingsUserLeaderboard,
 		SavingsTotalHistory,
+		SavingsStats,
 	} = context.db;
 	const { amount } = event.args;
 	const account: Address = event.args.account.toLowerCase() as Address;
@@ -140,6 +141,20 @@ ponder.on('Savings:Saved', async ({ event, context }) => {
 		update: () => ({
 			amountSaved,
 		}),
+	});
+
+	// Update total users count
+	const allUsers = await SavingsUserLeaderboard.findMany();
+	await SavingsStats.upsert({
+		id: 'global',
+		create: {
+			totalUsers: allUsers.items.length,
+			lastUpdated: event.block.timestamp,
+		},
+		update: {
+			totalUsers: allUsers.items.length,
+			lastUpdated: event.block.timestamp,
+		},
 	});
 
 	const totalSaved = await context.client.readContract({
@@ -343,6 +358,20 @@ ponder.on('Savings:Withdrawn', async ({ event, context }) => {
 		update: () => ({
 			amountSaved,
 		}),
+	});
+
+	// Update total users count
+	const allUsers = await SavingsUserLeaderboard.findMany();
+	await SavingsStats.upsert({
+		id: 'global',
+		create: {
+			totalUsers: allUsers.items.length,
+			lastUpdated: event.block.timestamp,
+		},
+		update: {
+			totalUsers: allUsers.items.length,
+			lastUpdated: event.block.timestamp,
+		},
 	});
 
 	const totalSaved = await context.client.readContract({


### PR DESCRIPTION
## Summary
Adds a new SavingsStats table to store aggregated statistics for efficient queries.

## Implementation
- New `SavingsStats` table with `totalUsers` field
- Automatically updates on each Saved event
- Single row with id='global' for global stats

## Benefits
- **O(1) query performance** for total user count
- **Eliminates need** to fetch all users in API
- **Reduces data transfer** - single row vs thousands
- **Future extensible** - can add more stats fields

## Related
- API PR: d-EURO/api#52