### PR TITLE
Add potential referral volume tracking with accrued interest

### DIFF
--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -360,6 +360,21 @@ export default createSchema((p) => ({
 		investVolume: p.bigint(),
 		savingsVolume: p.bigint(),
 		totalVolume: p.bigint(),
+		// NEU: Felder für potenzielle Volumen
+		potentialVolume: p.bigint().optional(),           // Total volume + accrued interest
+		totalAccruedInterest: p.bigint().optional(),      // Sum of all unclaimed interest
+		lastInterestUpdate: p.bigint().optional(),        // Timestamp of last calculation
+		referredUsersWithSavings: p.string().list().optional(), // Users with active savings
+	}),
+
+	// NEU: Tabelle für User Savings Tracking
+	UserSavingsTracking: p.createTable({
+		id: p.string(),                        // user address
+		frontendCode: p.string().optional(),
+		currentBalance: p.bigint(),
+		lastUpdateTicks: p.bigint(),
+		accruedInterest: p.bigint(),
+		lastCalculated: p.bigint(),
 	}),
 
 	FrontendRewardsVolumeMapping: p.createTable({

--- a/src/Savings.ts
+++ b/src/Savings.ts
@@ -4,6 +4,86 @@ import { ADDR } from '../ponder.config';
 import { Address, decodeFunctionData } from 'viem';
 import { getRandomHex } from './utils/randomString';
 
+// Track last block when we updated interest
+let lastInterestUpdateBlock = 0n;
+
+// Helper function to calculate accrued interest for a user
+async function calculateUserAccruedInterest(
+	client: any,
+	userAddress: Address
+): Promise<bigint> {
+	try {
+		// Get accrued interest directly from contract
+		const accruedInterest = await client.readContract({
+			abi: SavingsGatewayABI,
+			address: ADDR.savingsGateway,
+			functionName: 'accruedInterest',
+			args: [userAddress],
+		});
+		
+		return accruedInterest || 0n;
+	} catch (error) {
+		console.error(`Error calculating interest for ${userAddress}:`, error);
+		return 0n;
+	}
+}
+
+// Helper function to update potential volume for all frontend codes
+async function updateAllFrontendPotentialVolumes(context: any, timestamp: bigint) {
+	const { FrontendRewardsMapping, UserSavingsTracking } = context.db;
+	const { client } = context;
+	
+	// Get all frontend codes with referred users
+	const allFrontendCodes = await FrontendRewardsMapping.findMany({
+		limit: 1000,
+	});
+	
+	for (const frontend of allFrontendCodes.items) {
+		if (!frontend.referred || frontend.referred.length === 0) continue;
+		
+		let totalAccruedInterest = 0n;
+		const usersWithSavings: string[] = [];
+		
+		// Calculate accrued interest for each referred user
+		for (const userAddress of frontend.referred) {
+			const userTracking = await UserSavingsTracking.findUnique({
+				id: userAddress,
+			});
+			
+			if (userTracking && userTracking.currentBalance > 0n) {
+				const accruedInterest = await calculateUserAccruedInterest(client, userAddress as Address);
+				
+				if (accruedInterest > 0n) {
+					totalAccruedInterest += accruedInterest;
+					usersWithSavings.push(userAddress);
+					
+					// Update user tracking
+					await UserSavingsTracking.update({
+						id: userAddress,
+						data: {
+							accruedInterest,
+							lastCalculated: timestamp,
+						},
+					});
+				}
+			}
+		}
+		
+		// Update frontend rewards with potential volume
+		await FrontendRewardsMapping.update({
+			id: frontend.id,
+			data: {
+				potentialVolume: frontend.totalVolume + totalAccruedInterest,
+				totalAccruedInterest,
+				lastInterestUpdate: timestamp,
+				referredUsersWithSavings: usersWithSavings,
+			},
+		});
+	}
+	
+	console.log(`Updated potential volumes for ${allFrontendCodes.items.length} frontend codes at timestamp ${timestamp}`);
+}
+
 ponder.on('Savings:RateProposed', async ({ event, context }) => {
 	const { SavingsRateProposed } = context.db;
 	const { who, nextChange, nextRate } = event.args;
@@ -48,9 +128,17 @@ ponder.on('Savings:Saved', async ({ event, context }) => {
 		Ecosystem,
 		SavingsUserLeaderboard,
 		SavingsTotalHistory,
+		UserSavingsTracking,
+		FrontendRewardsMapping,
 	} = context.db;
 	const { amount } = event.args;
 	const account: Address = event.args.account.toLowerCase() as Address;
+	
+	// Check if we should update all frontend potential volumes (every 100 blocks)
+	if (event.block.number - lastInterestUpdateBlock >= 100n) {
+		lastInterestUpdateBlock = event.block.number;
+		await updateAllFrontendPotentialVolumes(context, event.block.timestamp);
+	}
 
 	const ratePPM = await client.readContract({
 		abi: SavingsABI,
@@ -160,14 +248,65 @@ ponder.on('Savings:Saved', async ({ event, context }) => {
 			total: totalSaved,
 		}),
 	});
+
+	// Update user savings tracking for potential volume
+	await UserSavingsTracking.upsert({
+		id: account,
+		create: {
+			frontendCode,
+			currentBalance: amountSaved,
+			lastUpdateTicks: event.block.timestamp,
+			accruedInterest: 0n,
+			lastCalculated: event.block.timestamp,
+		},
+		update: () => ({
+			frontendCode,
+			currentBalance: amountSaved,
+			lastUpdateTicks: event.block.timestamp,
+		}),
+	});
+
+	// Update frontend rewards if frontendCode exists
+	if (frontendCode) {
+		const frontendData = await FrontendRewardsMapping.findUnique({
+			id: frontendCode,
+		});
+		
+		if (frontendData) {
+			// Check if user is already in referred list
+			const isNewReferred = !frontendData.referred.includes(account);
+			const referredUsersWithSavings = frontendData.referredUsersWithSavings || [];
+			
+			if (!referredUsersWithSavings.includes(account) && amountSaved > 0n) {
+				referredUsersWithSavings.push(account);
+			}
+			
+			await FrontendRewardsMapping.update({
+				id: frontendCode,
+				data: {
+					referred: isNewReferred ? [...frontendData.referred, account] : frontendData.referred,
+					referredUsersWithSavings,
+					savingsVolume: frontendData.savingsVolume + amount,
+					totalVolume: frontendData.totalVolume + amount,
+					potentialVolume: frontendData.totalVolume + amount,
+				},
+			});
+		}
+	}
 });
 
 ponder.on('Savings:InterestCollected', async ({ event, context }) => {
 	const { client } = context;
-	const { SavingsInterest, SavingsSavedMapping, SavingsWithdrawnMapping, SavingsInterestMapping, Ecosystem, SavingsUserLeaderboard } =
+	const { SavingsInterest, SavingsSavedMapping, SavingsWithdrawnMapping, SavingsInterestMapping, Ecosystem, SavingsUserLeaderboard, UserSavingsTracking, FrontendRewardsMapping } =
 		context.db;
 	const { interest } = event.args;
 	const account: Address = event.args.account.toLowerCase() as Address;
+	
+	// Check if we should update all frontend potential volumes (every 100 blocks)
+	if (event.block.number - lastInterestUpdateBlock >= 100n) {
+		lastInterestUpdateBlock = event.block.number;
+		await updateAllFrontendPotentialVolumes(context, event.block.timestamp);
+	}
 
 	const ratePPM = await client.readContract({
 		abi: SavingsABI,
@@ -249,6 +388,46 @@ ponder.on('Savings:InterestCollected', async ({ event, context }) => {
 			interestReceived: current.interestReceived + interest,
 		}),
 	});
+
+	// Reset accrued interest for user when they claim
+	await UserSavingsTracking.upsert({
+		id: account,
+		create: {
+			frontendCode: undefined,
+			currentBalance: amountSaved,
+			lastUpdateTicks: event.block.timestamp,
+			accruedInterest: 0n,
+			lastCalculated: event.block.timestamp,
+		},
+		update: () => ({
+			accruedInterest: 0n,
+			lastUpdateTicks: event.block.timestamp,
+			lastCalculated: event.block.timestamp,
+			currentBalance: amountSaved,
+		}),
+	});
+
+	// Find user's frontend code and update volumes
+	const userTracking = await UserSavingsTracking.findUnique({
+		id: account,
+	});
+
+	if (userTracking?.frontendCode) {
+		const frontendData = await FrontendRewardsMapping.findUnique({
+			id: userTracking.frontendCode,
+		});
+
+		if (frontendData) {
+			await FrontendRewardsMapping.update({
+				id: userTracking.frontendCode,
+				data: {
+					savingsVolume: frontendData.savingsVolume + interest,
+					totalVolume: frontendData.totalVolume + interest,
+					potentialVolume: (frontendData.potentialVolume || frontendData.totalVolume) + interest,
+				},
+			});
+		}
+	}
 });
 
 ponder.on('Savings:Withdrawn', async ({ event, context }) => {
@@ -261,9 +440,16 @@ ponder.on('Savings:Withdrawn', async ({ event, context }) => {
 		Ecosystem,
 		SavingsUserLeaderboard,
 		SavingsTotalHistory,
+		UserSavingsTracking,
 	} = context.db;
 	const { amount } = event.args;
 	const account: Address = event.args.account.toLowerCase() as Address;
+	
+	// Check if we should update all frontend potential volumes (every 100 blocks)
+	if (event.block.number - lastInterestUpdateBlock >= 100n) {
+		lastInterestUpdateBlock = event.block.number;
+		await updateAllFrontendPotentialVolumes(context, event.block.timestamp);
+	}
 
 	const ratePPM = await client.readContract({
 		abi: SavingsABI,
@@ -361,6 +547,22 @@ ponder.on('Savings:Withdrawn', async ({ event, context }) => {
 		},
 		update: () => ({
 			total: totalSaved,
+		}),
+	});
+
+	// Update user savings tracking after withdrawal
+	await UserSavingsTracking.upsert({
+		id: account,
+		create: {
+			frontendCode: undefined,
+			currentBalance: amountSaved,
+			lastUpdateTicks: event.block.timestamp,
+			accruedInterest: 0n,
+			lastCalculated: event.block.timestamp,
+		},
+		update: () => ({
+			currentBalance: amountSaved,
+			lastUpdateTicks: event.block.timestamp,
 		}),
 	});
 });


### PR DESCRIPTION
## Summary
- Implements backend calculation of potential referral volumes including unclaimed interest
- Adds periodic updates every 100 blocks to calculate accrued interest
- Stores results in database to avoid frontend RPC calls

## Changes
- Added `UserSavingsTracking` table to track user savings balances and accrued interest
- Extended `FrontendRewardsMapping` with fields for potential volume tracking
- Implemented helper functions to calculate accrued interest from Savings contracts
- Added periodic update mechanism triggered every 100 blocks during event processing
- Updates potential volumes on all savings-related events (save, withdraw, interest claim)

## Benefits
- **Performance**: Backend calculation instead of frontend RPC calls
- **Scalability**: Works with any number of referred users
- **Accuracy**: Regular updates every 100 blocks (~20 minutes)
- **Reliability**: No RPC rate limits affecting frontend

## Test Plan
- [x] Schema changes compile successfully with `pnpm codegen`
- [x] Local indexer runs without errors
- [x] GraphQL queries return expected fields
- [ ] Verify interest calculations match on-chain values
- [ ] Test with multiple frontend codes and referred users
- [ ] Confirm periodic updates trigger correctly