### PR TITLE
Fix: Bridge transactions incorrectly counted as mints

### DIFF
--- a/src/stablecoin.ts
+++ b/src/stablecoin.ts
@@ -203,8 +203,16 @@ ponder.on('Stablecoin:Transfer', async ({ event, context }) => {
 		}),
 	});
 
+	// Check if this is a bridge transaction by looking for 'bridge' prefix in ADDR
+	const isBridgeTransaction = event.transaction.to && 
+		Object.entries(ADDR).some(([key, value]) => 
+			key.toLowerCase().startsWith('bridge') && 
+			value?.toLowerCase() === event.transaction.to?.toLowerCase()
+		);
+
 	// emit Transfer(address(0), recipient, amount);
-	if (event.args.from === zeroAddress) {
+	// Only count as mint if it's NOT a bridge transaction
+	if (event.args.from === zeroAddress && !isBridgeTransaction) {
 		await Mint.create({
 			id: `${event.transaction.hash}-${event.log.logIndex}`,
 			data: {


### PR DESCRIPTION
## Problem

Currently, bridge transactions (swaps from EURC, EURS, etc. to dEURO) are being incorrectly indexed as **both** mint events AND bridge events. This causes wrong social media announcements where swaps are reported as "New dEURO Mint!" instead of "New Swap!".

## Example Case

Transaction: https://etherscan.io/tx/0xfb98d96b8de90aedeb6def237e6cba045bbb35fc7bb43d65b256d6552aa964b7

This EURC → dEURO swap of 16,243.62 EURC triggered:
- ❌ **Wrong**: "New dEURO Mint! 🏦 Lending Amount: 16.243,62"  
- ✅ **Should be**: "New Swap! ↔️ EURC > dEURO"

## Root Cause

In `stablecoin.ts`, the Transfer event handler has a logic flaw:

1. When `event.args.from === zeroAddress`, it **always** creates a Mint event (line 208)
2. Later, if `event.transaction.to` is a bridge address, it **also** creates a Bridge event (line 345+)

This means bridge transactions get double-counted because they have:
- `from: 0x0000...` (triggers mint logic)
- `transaction.to: bridgeEURC` (triggers bridge logic)

## Solution

This PR adds a check to exclude bridge transactions from being counted as mints:

```typescript
// Check if this is a bridge transaction by looking for 'bridge' prefix in ADDR
const isBridgeTransaction = event.transaction.to && 
  Object.entries(ADDR).some(([key, value]) => 
    key.toLowerCase().startsWith('bridge') && 
    value?.toLowerCase() === event.transaction.to?.toLowerCase()
  );

// Only count as mint if it's NOT a bridge transaction
if (event.args.from === zeroAddress && !isBridgeTransaction) {
  // Create mint event
}
```

## Benefits

1. **Correct Event Classification**: Bridge swaps are only counted as bridges, not mints
2. **Accurate Social Media**: Correct announcements ("New Swap!" for bridges, "New dEURO Mint!" for actual mints)
3. **Generic Solution**: Automatically works for all current and future bridge contracts (bridgeEURC, bridgeEURS, etc.)
4. **Maintainable**: No hardcoded list of bridge addresses

## Testing

The fix can be verified by:
1. Reindexing bridge transactions - they should only appear in Bridge tables, not Mint tables
2. Checking social media announcements - swaps should show "New Swap!" messages
3. Confirming actual mints (non-bridge) still work correctly

## Impact

This is a critical fix for accurate reporting and social media announcements. Without this fix, every bridge swap is incorrectly announced as a new mint, which confuses users and misrepresents the actual minting activity.