### PR TITLE
feat: Add SavingsStats table for aggregated statistics (#27)

### DIFF
--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -170,6 +170,12 @@ export default createSchema((p) => ({
 		interestReceived: p.bigint(),
 	}),
 
+	SavingsStats: p.createTable({
+		id: p.string(), // Will be 'global' for single row
+		totalUsers: p.int(),
+		lastUpdated: p.bigint(),
+	}),
+
 	SavingsTotalHistory: p.createTable({
 		id: p.string(),
 		time: p.bigint(),


### PR DESCRIPTION
* feat: add SavingsStats table for efficient user count queries

- New SavingsStats table stores aggregated statistics
- Automatically updates total user count on each save event
- Provides O(1) query performance for total users
- Eliminates need to fetch and count all users in API

* fix: optimize SavingsStats update logic

- Check for existing user BEFORE upsert to detect new users correctly
- Only increment counter for truly new users (not updates)
- Remove unnecessary stats update from Withdrawn event
- Use incremental counting instead of counting all users
- Eliminates findMany() performance issue

* fix: restore SavingsUserLeaderboard update in Withdrawn event

- Remove incorrect user counting from Withdrawn event
- Users should only be counted on their first SAVE event
- Keep leaderboard update for withdrawal tracking

---------