### PR TITLE
Scale ChallengeSucceeded bid to 18 decimals

### DIFF
--- a/src/MintingHubV2.ts
+++ b/src/MintingHubV2.ts
@@ -383,7 +383,7 @@ ponder.on('MintingHubV2:ChallengeSucceeded', async ({ event, context }) => {
 		bidder: getAddress(event.transaction.from),
 		created: event.block.timestamp,
 		bidType: 'Succeeded',
-		bid: event.args.bid,
+		bid: event.args.bid * 10n ** 18n,
 		price: BigInt(_price),
 		filledSize: event.args.challengeSize,
 		acquiredCollateral: event.args.acquiredCollateral,


### PR DESCRIPTION
The `ChallengeSucceeded` handler now stores `bid` multiplied by `10^18` so it matches the unit convention used for other bid types in the indexer.