### PR TITLE
ci: Ponder schema suffix via COMMIT_HASH build-arg

### DIFF
--- a/.github/workflows/api-dev.yaml
+++ b/.github/workflows/api-dev.yaml
@@ -31,12 +31,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Get short SHA
+        id: sha
+        run: echo "short=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           tags: ${{ env.DOCKER_TAGS }}
+          build-args: |
+            COMMIT_HASH=${{ steps.sha.outputs.short }}
 
       - name: Log in to Azure
         uses: azure/login@v2

--- a/.github/workflows/api-prd.yaml
+++ b/.github/workflows/api-prd.yaml
@@ -31,12 +31,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Get short SHA
+        id: sha
+        run: echo "short=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           tags: ${{ env.DOCKER_TAGS }}
+          build-args: |
+            COMMIT_HASH=${{ steps.sha.outputs.short }}
 
       - name: Log in to Azure
         uses: azure/login@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ RUN mkdir /app && chown -R node:node /app
 WORKDIR /app
 USER node
 
+ARG COMMIT_HASH=public
+ENV COMMIT_HASH=${COMMIT_HASH}
+
 COPY --chown=node . .
 RUN yarn install --production --frozen-lockfile
 


### PR DESCRIPTION
Aligns Docker/CI with the JuiceDollar setup so each image bakes the short Git SHA into `COMMIT_HASH` and Ponder runs with `--schema schema-${COMMIT_HASH}`.

### Changes
- **Dockerfile:** `ARG COMMIT_HASH=public` and `ENV` so local/default builds use `schema-public`.
- **api-dev / api-prd workflows:** `Get short SHA` step and `build-args` on the Docker build.