### PR TITLE
chore: bump @deuro/eurocoin to 2.1.0 and use V2 ABIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
 		"typecheck": "tsc"
 	},
 	"dependencies": {
-		"@deuro/eurocoin": "1.0.13",
-		"ponder": "^0.16.6",
+		"@deuro/eurocoin": "2.1.0",
 		"hono": "^4.10.0",
 		"pg": "^8.11.3",
+		"ponder": "^0.16.6",
 		"viem": "^2.47.6"
 	},
 	"devDependencies": {

--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -7,10 +7,10 @@ import {
 	EquityABI,
 	DecentralizedEUROABI,
 	MintingHubV2ABI,
-	PositionRollerABI,
+	PositionRollerV2ABI,
 	PositionV2ABI,
-	SavingsABI,
-	FrontendGatewayABI,
+	SavingsV2ABI,
+	FrontendGatewayV2ABI,
 } from '@deuro/eurocoin';
 
 // mainnet (default) or polygon
@@ -84,20 +84,20 @@ export default createConfig({
 		Savings: {
 			// V2
 			chain: chain.name,
-			abi: SavingsABI,
+			abi: SavingsV2ABI,
 			address: ADDR.savingsGateway as Address,
 			startBlock: config.startMintingHubV2,
 		},
 		Roller: {
 			// V2
 			chain: chain.name,
-			abi: PositionRollerABI,
-			address: ADDR.roller as Address,
+			abi: PositionRollerV2ABI,
+			address: ADDR.rollerV2 as Address,
 			startBlock: config.startMintingHubV2,
 		},
 		FrontendGateway: {
 			chain: chain.name,
-			abi: FrontendGatewayABI,
+			abi: FrontendGatewayV2ABI,
 			address: ADDR.frontendGateway as Address,
 			startBlock: config.startMintingHubV2,
 		},

--- a/src/Savings.ts
+++ b/src/Savings.ts
@@ -1,5 +1,5 @@
 import { ponder } from 'ponder:registry';
-import { ERC20ABI, SavingsABI, SavingsGatewayABI } from '@deuro/eurocoin';
+import { ERC20ABI, SavingsV2ABI, SavingsGatewayV2ABI } from '@deuro/eurocoin';
 import { ADDR } from '../ponder.config';
 import { Address, decodeFunctionData, getAddress } from 'viem';
 import {
@@ -51,7 +51,7 @@ ponder.on('Savings:Saved', async ({ event, context }) => {
 	const account: Address = event.args.account.toLowerCase() as Address;
 
 	const ratePPM = await client.readContract({
-		abi: SavingsABI,
+		abi: SavingsV2ABI,
 		address: ADDR.savingsGateway,
 		functionName: 'currentRatePPM',
 	});
@@ -59,7 +59,7 @@ ponder.on('Savings:Saved', async ({ event, context }) => {
 	let frontendCode: string | undefined;
 	if (event.transaction.to?.toLowerCase() === ADDR.savingsGateway.toLowerCase()) {
 		const { args } = decodeFunctionData({
-			abi: SavingsGatewayABI,
+			abi: SavingsGatewayV2ABI,
 			data: event.transaction.input,
 		});
 		frontendCode = args.at(-1) as string;
@@ -106,7 +106,7 @@ ponder.on('Savings:Saved', async ({ event, context }) => {
 		.onConflictDoUpdate((row) => ({ amount: row.amount + amount }));
 
 	const [amountSaved] = await client.readContract({
-		abi: SavingsABI,
+		abi: SavingsV2ABI,
 		address: ADDR.savingsGateway,
 		functionName: 'savings',
 		args: [account],
@@ -150,7 +150,7 @@ ponder.on('Savings:InterestCollected', async ({ event, context }) => {
 	const account: Address = event.args.account.toLowerCase() as Address;
 
 	const ratePPM = await client.readContract({
-		abi: SavingsABI,
+		abi: SavingsV2ABI,
 		address: ADDR.savingsGateway,
 		functionName: 'currentRatePPM',
 	});
@@ -195,7 +195,7 @@ ponder.on('Savings:InterestCollected', async ({ event, context }) => {
 		.onConflictDoUpdate((row) => ({ amount: row.amount + interest }));
 
 	const [amountSaved] = await client.readContract({
-		abi: SavingsABI,
+		abi: SavingsV2ABI,
 		address: ADDR.savingsGateway,
 		functionName: 'savings',
 		args: [account],
@@ -216,7 +216,7 @@ ponder.on('Savings:Withdrawn', async ({ event, context }) => {
 	const account: Address = event.args.account.toLowerCase() as Address;
 
 	const ratePPM = await client.readContract({
-		abi: SavingsABI,
+		abi: SavingsV2ABI,
 		address: ADDR.savingsGateway,
 		functionName: 'currentRatePPM',
 	});
@@ -261,7 +261,7 @@ ponder.on('Savings:Withdrawn', async ({ event, context }) => {
 		.onConflictDoUpdate((row) => ({ amount: row.amount + amount }));
 
 	const [amountSaved] = await client.readContract({
-		abi: SavingsABI,
+		abi: SavingsV2ABI,
 		address: ADDR.savingsGateway,
 		functionName: 'savings',
 		args: [account],

--- a/src/equity.ts
+++ b/src/equity.ts
@@ -1,7 +1,7 @@
 import { ponder } from 'ponder:registry';
 import { Address, decodeFunctionData, getAddress, RpcTransaction, zeroAddress } from 'viem';
 import { ADDR } from '../ponder.config';
-import { FrontendGatewayABI } from '@deuro/eurocoin';
+import { FrontendGatewayV2ABI } from '@deuro/eurocoin';
 import { trade, votingPower, tradeChart, activeUser, ecosystem, deps, delegation } from '../ponder.schema';
 
 ponder.on('Equity:Trade', async ({ event, context }) => {
@@ -22,7 +22,7 @@ ponder.on('Equity:Trade', async ({ event, context }) => {
 		})) as RpcTransaction;
 
 		const decoded = decodeFunctionData({
-			abi: FrontendGatewayABI,
+			abi: FrontendGatewayV2ABI,
 			data: txRaw.input,
 		});
 

--- a/src/stablecoin.ts
+++ b/src/stablecoin.ts
@@ -1,7 +1,7 @@
 import { ponder } from 'ponder:registry';
 import { Address, getAddress, zeroAddress, decodeEventLog } from 'viem';
 import { ADDR } from '../ponder.config';
-import { MintingHubGatewayABI } from '@deuro/eurocoin';
+import { MintingHubGatewayV2ABI } from '@deuro/eurocoin';
 import {
 	deps,
 	activeUser,
@@ -188,7 +188,7 @@ ponder.on('Stablecoin:Transfer', async ({ event, context }) => {
 				.filter((log) => log.address.toLowerCase() === ADDR.mintingHubGateway.toLowerCase())
 				.map(({ data, topics }) =>
 					decodeEventLog({
-						abi: MintingHubGatewayABI,
+						abi: MintingHubGatewayV2ABI,
 						data: data as `0x${string}`,
 						topics: topics as [`0x${string}`, ...`0x${string}`[]],
 					})

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,12 +47,11 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@deuro/eurocoin@1.0.13":
-  version "1.0.13"
-  resolved "https://registry.npmjs.org/@deuro/eurocoin/-/eurocoin-1.0.13.tgz"
-  integrity sha512-NrAHpgLrlx662BgTcgkxBXNvNPl+bUeQPaVGwOsDrJXyVsJJVfpBwPcqZ+CaOVUEZfwDePYTWZe2e82bVqRkTQ==
+"@deuro/eurocoin@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@deuro/eurocoin/-/eurocoin-2.1.0.tgz#20a4fcaf64862ffe11e21c4cc486025d7395f4a1"
+  integrity sha512-Yx2XGEmNT7kshKmT9cgtryo7LkB76Bk3FmcAuxvWHUmAnQZAEGwBU0Ay1/SKzZWCMzGivsQRn5jx7KPz5t62AA==
   dependencies:
-    "@flashbots/ethers-provider-bundle" "^1.0.0"
     hardhat-abi-exporter "^2.10.0"
     hardhat-contract-sizer "^2.5.1"
     prettier "^3.3.3"
@@ -602,11 +601,6 @@
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-3.2.0.tgz#13ed8212f3b9ba697611529d15347f8528058cea"
   integrity sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==
-
-"@flashbots/ethers-provider-bundle@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@flashbots/ethers-provider-bundle/-/ethers-provider-bundle-1.0.0.tgz"
-  integrity sha512-KXOSA2RFFq91KN7H6nskbBaV+yd3QKI9jj8r1CEsD00sXBV3uSoQ3wG6u7qkjxp2EfvWy31pynWfZZVoWyNQ3Q==
 
 "@graphql-tools/executor@^1.5.0":
   version "1.5.1"


### PR DESCRIPTION
Updates the indexer to `@deuro/eurocoin` 2.1.0 and switches contract bindings to the V2 ABI exports (`SavingsV2ABI`, `SavingsGatewayV2ABI`, `PositionRollerV2ABI`, `FrontendGatewayV2ABI`, `MintingHubGatewayV2ABI`). The Roller contract in `ponder.config.ts` now uses `ADDR.rollerV2`.

`yarn typecheck` passes locally.