### PR TITLE
fix: replace rateLimit transport with chain-level config

### DIFF
--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -1,4 +1,4 @@
-import { createConfig, factory, rateLimit } from 'ponder';
+import { createConfig, factory } from 'ponder';
 import { mainnet, polygon } from 'viem/chains';
 import { Address, http } from 'viem';
 import { AbiEvent } from 'abitype';
@@ -44,7 +44,8 @@ export default createConfig({
 	chains: {
 		[chain.name]: {
 			id: Id,
-			rpc: rateLimit(http(config.rpc), { requestsPerSecond: config.maxRequestsPerSecond }),
+			rpc: http(config.rpc),
+			maxRequestsPerSecond: config.maxRequestsPerSecond,
 			pollingInterval: config.pollingInterval,
 		},
 	},


### PR DESCRIPTION
## Summary
- Replace `rateLimit()` transport wrapper with `maxRequestsPerSecond` at chain level
- Matches upstream Frankencoin ponder configuration pattern
- Fixes intermittent 30-56s block indexing delays after transient RPC errors

## Problem
The `rateLimit()` transport wrapper from ponder aggressively reduces the request rate on transient errors (DNS timeouts, RPC hiccups) — from 50 req/s down to ~12 req/s — and enters a slow warm-up phase that takes 10+ minutes to recover. This caused ~50% uptime on the DEV status page.

## Fix
Use ponder's built-in `maxRequestsPerSecond` chain-level option instead, which handles error recovery more gracefully without the aggressive exponential back-off.

## Test plan
- [ ] Deploy to DEV and verify ponder processes blocks consistently in <100ms
- [ ] Monitor status page for improved uptime
- [ ] Verify no regressions in backfill indexing