### PR TITLE
Replace Azure deploy with SSH deploy via Cloudflare Tunnel

### DIFF
--- a/.github/workflows/api-dev.yaml
+++ b/.github/workflows/api-dev.yaml
@@ -7,8 +7,6 @@ on:
 
 env:
   DOCKER_TAGS: dfxswiss/deuro-ponder:beta
-  DEPLOY_HOST: ssh-dfxdev.dfxserve.com
-  DEPLOY_USER: dfxdev
   DEPLOY_SERVICE: deuro-ponder
 
 jobs:
@@ -43,16 +41,16 @@ jobs:
 
       - name: Install cloudflared
         run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
           chmod +x /usr/local/bin/cloudflared
 
-      - name: Deploy to dfxdev
+      - name: Deploy to server
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.DFXDEV_SSH_KEY }}" > ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          echo "${{ secrets.DFXDEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          echo "${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
           ssh -i ~/.ssh/deploy_key \
-            -o ProxyCommand="cloudflared access ssh --hostname ${{ env.DEPLOY_HOST }}" \
-            ${{ env.DEPLOY_USER }}@${{ env.DEPLOY_HOST }} \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_HOST }}" \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
             "${{ env.DEPLOY_SERVICE }}"

--- a/.github/workflows/api-dev.yaml
+++ b/.github/workflows/api-dev.yaml
@@ -47,9 +47,6 @@ jobs:
           chmod +x /usr/local/bin/cloudflared
 
       - name: Deploy to dfxdev
-        env:
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.DFXDEV_SSH_KEY }}" > ~/.ssh/deploy_key

--- a/.github/workflows/api-dev.yaml
+++ b/.github/workflows/api-dev.yaml
@@ -7,17 +7,14 @@ on:
 
 env:
   DOCKER_TAGS: dfxswiss/deuro-ponder:beta
-  AZURE_RESOURCE_GROUP: rg-dfx-api-dev
-  AZURE_CONTAINER_APP: ca-dfx-dep-dev
-  DEPLOY_INFO: ${{ github.ref_name }}-${{ github.sha }}
+  DEPLOY_HOST: ssh-dfxdev.dfxserve.com
+  DEPLOY_USER: dfxdev
+  DEPLOY_SERVICE: deuro-ponder
 
 jobs:
   build-and-deploy:
-    name: Build, test and deploy to DEV
+    name: Build and deploy to DEV
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: .
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,35 +41,21 @@ jobs:
           build-args: |
             COMMIT_HASH=${{ steps.sha.outputs.short }}
 
-      - name: Log in to Azure
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.DFX_DEV_CREDENTIALS }}
-
-      - name: Update Azure Container App
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            CURRENT_REVISION=$(az containerapp revision list \
-              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-              --name ${{ env.AZURE_CONTAINER_APP }} \
-              --query "[?properties.active].name" \
-              --output tsv | head -1)
-
-            echo "CURRENT_REVISION=$CURRENT_REVISION" >> $GITHUB_ENV
-
-            az containerapp update \
-              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-              --name ${{ env.AZURE_CONTAINER_APP }} \
-              --image ${{ env.DOCKER_TAGS }} \
-              --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}
-
-            az containerapp revision deactivate \
-              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-              --name ${{ env.AZURE_CONTAINER_APP }} \
-              --revision $CURRENT_REVISION
-
-      - name: Logout from Azure
+      - name: Install cloudflared
         run: |
-          az logout
-        if: always()
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+
+      - name: Deploy to dfxdev
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DFXDEV_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DFXDEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ env.DEPLOY_HOST }}" \
+            ${{ env.DEPLOY_USER }}@${{ env.DEPLOY_HOST }} \
+            "${{ env.DEPLOY_SERVICE }}"

--- a/.github/workflows/ponder-dev.yaml
+++ b/.github/workflows/ponder-dev.yaml
@@ -23,6 +23,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -36,6 +39,7 @@ jobs:
           context: .
           push: true
           tags: ${{ env.DOCKER_TAGS }}
+          platforms: linux/amd64,linux/arm64
           build-args: |
             COMMIT_HASH=${{ steps.sha.outputs.short }}
 

--- a/.github/workflows/ponder-dev.yaml
+++ b/.github/workflows/ponder-dev.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_TAGS: dfxswiss/deuro-ponder:beta
+  DOCKER_TAGS: deurocom/ponder:beta
   DEPLOY_SERVICE: deuro-ponder
 
 jobs:


### PR DESCRIPTION
## Summary
Replace Azure Container App deployment with SSH deployment via Cloudflare Tunnel.

- Docker Hub push (`:beta` tag) remains unchanged  
- Deploy uses command-restricted SSH key
- Host and user details stored as secrets

## Required GitHub Secrets
| Secret | Description |
|---|---|
| `DEPLOY_SSH_KEY` | SSH private key (ed25519) |
| `DEPLOY_SSH_KNOWN_HOSTS` | SSH host key verification |
| `DEPLOY_HOST` | Target SSH hostname |
| `DEPLOY_USER` | Target SSH username |