### PR TITLE
Deploy verification test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# deploy-test
 FROM node:lts-alpine
 
 RUN mkdir /app && chown -R node:node /app


### PR DESCRIPTION
Temporary change to verify end-to-end deployment pipeline.

### Change
- Added `# deploy-test` comment to Dockerfile (line 1)

### Verification
After deployment, the new commit hash will appear in the ponder schema name in docker logs:
```
docker logs deuro-ponder 2>&1 | grep schema
```