### PR TITLE
Enable ARM64 Docker builds for Apple Silicon servers

### DIFF
--- a/.github/workflows/api-prd.yaml
+++ b/.github/workflows/api-prd.yaml
@@ -28,6 +28,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -41,6 +44,7 @@ jobs:
           context: .
           push: true
           tags: ${{ env.DOCKER_TAGS }}
+          platforms: linux/amd64,linux/arm64
           build-args: |
             COMMIT_HASH=${{ steps.sha.outputs.short }}
 


### PR DESCRIPTION
## Summary
- Add QEMU setup step and `platforms: linux/amd64,linux/arm64` to the PRD workflow (`api-prd.yaml`)
- The DEV workflow (`ponder-dev.yaml`) already has multi-arch support — this PR brings PRD in line
- Eliminates amd64 emulation overhead when running on ARM64 servers (Apple Silicon)
- Follows the same pattern already established in frankencoin-ponder

## Changes
- `.github/workflows/api-prd.yaml`: Added `docker/setup-qemu-action@v3` step before Docker Buildx, added `platforms: linux/amd64,linux/arm64` to `build-push-action`

## Test plan
- [ ] Verify PRD workflow builds successfully for both architectures
- [ ] Verify the resulting multi-arch image runs correctly on ARM64 and amd64 hosts