### PR TITLE
Switch to ARM64-only Docker builds for Apple Silicon servers

### DIFF
--- a/.github/workflows/api-prd.yaml
+++ b/.github/workflows/api-prd.yaml
@@ -7,17 +7,12 @@ on:
 
 env:
   DOCKER_TAGS: dfxswiss/deuro-ponder:latest
-  AZURE_RESOURCE_GROUP: rg-dfx-api-prd
-  AZURE_CONTAINER_APP: ca-dfx-dep-prd
-  DEPLOY_INFO: ${{ github.ref_name }}-${{ github.sha }}
+  DEPLOY_SERVICE: deuro-ponder
 
 jobs:
   build-and-deploy:
     name: Build, test and deploy to PRD
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: .
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,9 +22,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -44,39 +36,22 @@ jobs:
           context: .
           push: true
           tags: ${{ env.DOCKER_TAGS }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           build-args: |
             COMMIT_HASH=${{ steps.sha.outputs.short }}
 
-      - name: Log in to Azure
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.DFX_PRD_CREDENTIALS }}
-
-      - name: Update Azure Container App
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            CURRENT_REVISION=$(az containerapp revision list \
-              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-              --name ${{ env.AZURE_CONTAINER_APP }} \
-              --query "[?properties.active].name" \
-              --output tsv | head -1)
-
-            echo "CURRENT_REVISION=$CURRENT_REVISION" >> $GITHUB_ENV
-
-            az containerapp update \
-              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-              --name ${{ env.AZURE_CONTAINER_APP }} \
-              --image ${{ env.DOCKER_TAGS }} \
-              --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}
-
-            az containerapp revision deactivate \
-              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-              --name ${{ env.AZURE_CONTAINER_APP }} \
-              --revision $CURRENT_REVISION
-
-      - name: Logout from Azure
+      - name: Install cloudflared
         run: |
-          az logout
-        if: always()
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+
+      - name: Deploy to server
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_PRD_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_PRD_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_PRD_HOST }}" \
+            ${{ secrets.DEPLOY_PRD_USER }}@${{ secrets.DEPLOY_PRD_HOST }} \
+            "${{ env.DEPLOY_SERVICE }}"

--- a/.github/workflows/ponder-dev.yaml
+++ b/.github/workflows/ponder-dev.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
   build-and-deploy:
     name: Build and deploy to DEV
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,9 +22,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -39,13 +36,13 @@ jobs:
           context: .
           push: true
           tags: ${{ env.DOCKER_TAGS }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           build-args: |
             COMMIT_HASH=${{ steps.sha.outputs.short }}
 
       - name: Install cloudflared
         run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
           chmod +x /usr/local/bin/cloudflared
 
       - name: Deploy to server


### PR DESCRIPTION
## Summary
- Switch all CI/CD runners from `ubuntu-latest` to `ubuntu-24.04-arm` for native ARM64 builds
- Remove QEMU emulation setup (no longer needed with native ARM64 runners)
- Build only `linux/arm64` Docker images instead of multi-arch (`linux/amd64,linux/arm64`)
- Replace Azure Container App deployment in PRD with SSH deploy via cloudflared (same pattern as DEV)
- Use `cloudflared-linux-arm64` binary matching the ARM64 runner architecture

## Affected workflows
- `ponder-dev.yaml` — runner, QEMU removal, platform, cloudflared URL
- `api-prd.yaml` — runner, QEMU removal, platform, Azure → SSH deploy

## Test plan
- [ ] Verify DEV workflow triggers on develop push and builds ARM64 image
- [ ] Verify PRD workflow triggers on main push and deploys via SSH
- [ ] Confirm Docker images are ARM64-only on Docker Hub