### PR TITLE
Use deurocom Docker registry for PRD images

### DIFF
--- a/.github/workflows/api-prd.yaml
+++ b/.github/workflows/api-prd.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_TAGS: dfxswiss/deuro-ponder:latest
+  DOCKER_TAGS: deurocom/ponder:latest
   DEPLOY_SERVICE: deuro-ponder
 
 jobs:

--- a/.github/workflows/ponder-dev.yaml
+++ b/.github/workflows/ponder-dev.yaml
@@ -48,10 +48,10 @@ jobs:
       - name: Deploy to server
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_DEV_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          echo "${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          echo "${{ secrets.DEPLOY_DEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
           ssh -i ~/.ssh/deploy_key \
-            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_HOST }}" \
-            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_DEV_HOST }}" \
+            ${{ secrets.DEPLOY_DEV_USER }}@${{ secrets.DEPLOY_DEV_HOST }} \
             "${{ env.DEPLOY_SERVICE }}"


### PR DESCRIPTION
## Summary
- Switch PRD Docker image from `dfxswiss/deuro-ponder:latest` to `deurocom/ponder:latest`
- Rename deploy secrets to consistent `DEPLOY_DEV_*` / `DEPLOY_PRD_*` pattern

## Test plan
- [ ] Verify CI builds and pushes to correct registry
- [ ] Verify PRD deploy works